### PR TITLE
updated for dns zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "helm_release" issuer {
       server         = lookup(local.le_endpoint, each.value.letsencrypt_endpoint, each.value.letsencrypt_endpoint)
       secretName     = "cert-manager-issuer-${each.key}"
       subscriptionID = var.subscription_id
-      resourceGroup  = var.resource_group_name
+      resourceGroup  = var.dns_resource_group_name
       dnsZone        = each.value.domain
     })
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "resource_group_name"{
   type        = string
 }
 
+variable "dns_resource_group_name"{
+  description = "Resource group name for dns zone"
+  type        = string
+}
+
 variable "location" {
   description = "Azure Region"
   type        = string


### PR DESCRIPTION
current module assumes the resource group of the helm release issuer is in the same resource group as the AKS service. 

this change adds support for dns zones that are in other resource groups

//as is it throws this error if a dns zone is in another resource group
Error presenting challenge: dns.RecordSetsClient
 
 #CreateOrUpdate: Failure responding to request: 
 StatusCode=403 -- Original Error: autorest/azure: Service returned an error. 
 Status=403 Code="AuthorizationFailed"

@dutsmiller 